### PR TITLE
fix: flush before shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,7 @@ function logstashTCP(config, layout) {
     }
 
     log.shutdown = function (cb) {
-        tcpConnectionPool.close();
-        cb();
+        tcpConnectionPool.close(cb);
     };
 
     return log;


### PR DESCRIPTION
Properly end/flush all opened sockets before shutdown.
Fixes https://github.com/log4js-node/log4js-node/issues/1384.